### PR TITLE
Couple of potential improvements to the code

### DIFF
--- a/fasta.py
+++ b/fasta.py
@@ -199,13 +199,7 @@ def to_dict(sequences):
         >>> len(pdict)
         2
     """
-    d = dict()
-    for record in sequences:
-        key = record.id
-        if key in d:
-            raise ValueError(f"Duplicate key '{key}'")
-        d[key] = record
-    return d
+    return {record.id: record for record in sequences}
 
 
 def get_compression_type(filename: typing.Union[str, pathlib.Path]) -> str:

--- a/fasta.py
+++ b/fasta.py
@@ -9,7 +9,8 @@ import gzip
 import pathlib
 import typing
 
-class Record():
+
+class Record:
     """Object representing a FASTA (aka Pearson) record.
 
     Attributes:
@@ -213,18 +214,19 @@ def get_compression_type(filename: typing.Union[str, pathlib.Path]) -> str:
     Returns:
         Compression type (gz, bz2, plain)
     """
-    magic_dict = {'gz': (b'\x1f', b'\x8b', b'\x08'),
-                  'bz2': (b'\x42', b'\x5a', b'\x68'),
-                  'zip': (b'\x50', b'\x4b', b'\x03', b'\x04')}
-    max_len = max(len(x) for x in magic_dict)
+    magic_dict = {(b'\x1f', b'\x8b', b'\x08'): 'gz',
+                  (b'\x42', b'\x5a', b'\x68'): 'bz2',
+                  (b'\x50', b'\x4b', b'\x03', b'\x04'): 'zip'}
+    # since recognized compressions are not added dynamically, the max size of magic bytes can be static
+    max_len = 4
 
     fh = open(str(filename), 'rb')
     file_start = fh.read(max_len)
     fh.close()
     compression_type = 'plain'
-    for file_type, magic_bytes in magic_dict.items():
+    for magic_bytes in magic_dict:
         if file_start.startswith(magic_bytes):
-            compression_type = file_type
+            compression_type = magic_dict[magic_bytes]
     return compression_type
 
 

--- a/fasta.py
+++ b/fasta.py
@@ -227,11 +227,9 @@ def get_compression_type(filename: typing.Union[str, pathlib.Path]) -> str:
     fh = open(str(filename), 'rb')
     file_start = fh.read(max_len)
     fh.close()
-    compression_type = 'plain'
-    for magic_bytes in magic_dict:
-        if file_start.startswith(magic_bytes):
-            compression_type = magic_dict[magic_bytes]
-    return compression_type
+    compression_type = [magic_dict[elem] for elem in magic_dict if file_start.startswith(elem)]
+
+    return compression_type[0] if compression_type else 'plain'
 
 
 def get_open_func(filename: typing.Union[str, pathlib.Path]):


### PR DESCRIPTION
I wrote some potential improvements to the code:

- in [0927c35]( https://github.com/aziele/fasta-parser/commit/0927c3583ef0c7ee963ab3103ff968849af34f03) I've fixed a bug in which magic bytes were not read entirely for 'zip' because the max_len variable was derived from the length of the keys (which were the names of compression algorithms) and not from the actual bytes. Keys were exchanged with values and set the fixed size of the max_len variable since it's not being set dynamically (list comprehension skip).
- in [9a2e7e3](https://github.com/aziele/fasta-parser/commit/9a2e7e3d6086ee146ffbc3d29d45dfa56a7e5cf3) I've added zstandard and lz4 compression algorithms handling and rewritten the logic behind get_open_func to skip 'if' blocks so that a larger list of file types can be handled without compromising code readability and performance.
- in [274c8bf](https://github.com/aziele/fasta-parser/commit/274c8bfeee5bdeb0eac46328ac02da7e3a5015d8) I've skipped plain 'for-loop' with 'if' block with a list comprehension to potentially speed up the iteration, although the effect would be visible for larger list of the file types.
- in [48e3fa3](https://github.com/aziele/fasta-parser/commit/48e3fa3c238a46aca3a7c987fab7d631d14d4298) I've skipped plain 'for-loop' with 'if' block with a dictionary comprehension to potentially speed up the dictionary creation. The performance gain should be visible for large lists of records. But there is an issue with the exception that was raised in the original implementation - now, no exception is being raised for duplicate records. Instead, dictionary comprehension skips any duplicate keys, but I am not sure if this lines up with the intention of the original implementation.